### PR TITLE
Add more advanced date filtering to dashboard and entries views

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,15 +72,16 @@ In the root...
 
 ### Development
 
-In `./client`...
+To run with Docker: `docker compose -f docker-compose.dev.yml --env-file ./server/.env up`
 
-- `npm start` to run the project at `localhost:3000`
-- and other basic installation/build scripts, as required
+Or directly:
 
-In `./server`...
-
-- `npm run dev` to run the backend in development mode with hot reloading at `localhost:4000/graphql`
-- and other basic installation/build scripts, as required
+- In `./client`...
+  - `npm start` to run the project at `localhost:3000`
+  - and other basic installation/build scripts, as required
+- In `./server`...
+  - `npm run dev` to run the backend in development mode with hot reloading at `localhost:4000/graphql`
+  - and other basic installation/build scripts, as required
 
 ### Testing
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -41,7 +41,9 @@
 - Bug: entry modal fails, if there are no categories ✅
 - Remove zeroing of date in entries to allow proper sorting (same day entries) ✅
 - Containerize the project ✅
+- Allow day selection in views (not only monthly)
 - Add category filtering to entries' view
+- Add "more info" option to expenses table view to make the view simpler to digest
 - Test coverage for client is sufficient (considering unfinalised UI)
 
 ## Next steps

--- a/client/src/cache.ts
+++ b/client/src/cache.ts
@@ -1,5 +1,5 @@
 import { InMemoryCache, makeVar, ReactiveVar } from "@apollo/client";
-import { localStorageUser, Space } from "./types";
+import { localStorageUser, Space, ViewDateRange } from "./types";
 
 // Add logged in status to cache and make it callable (read())
 const cache: InMemoryCache = new InMemoryCache({
@@ -23,7 +23,7 @@ const cache: InMemoryCache = new InMemoryCache({
         },
         currentViewMonth: {
           read() {
-            return currentViewMonthVar();
+            return currentViewDateRangeVar();
           },
         },
       },
@@ -41,8 +41,6 @@ export const isLoggedInVar: ReactiveVar<boolean> = makeVar<boolean>(
 
 const localUser = localStorage.getItem("outcome-user");
 const initLocalUser = localUser ? JSON.parse(localUser) : null;
-const today = new Date();
-const currentDate = new Date(today.getFullYear(), today.getMonth());
 
 export const currentUserVar: ReactiveVar<localStorageUser> =
   makeVar<localStorageUser>(initLocalUser);
@@ -51,5 +49,9 @@ export const activeSpaceVar: ReactiveVar<Space> = makeVar<Space>(
   initLocalUser ? initLocalUser.spaces[0] : null
 );
 
-export const currentViewMonthVar: ReactiveVar<Date> =
-  makeVar<Date>(currentDate);
+const today = new Date();
+const startDate = new Date(today.getFullYear(), today.getMonth());
+const endDate = new Date(today.getFullYear(), today.getMonth() + 1);
+
+export const currentViewDateRangeVar: ReactiveVar<ViewDateRange> =
+  makeVar<ViewDateRange>({ start: startDate, end: endDate });

--- a/client/src/components/BottomNavigation.tsx
+++ b/client/src/components/BottomNavigation.tsx
@@ -1,12 +1,8 @@
-import { useQuery } from "@apollo/client";
-import { useEffect, useState } from "react";
 import { useLocation } from "react-router-dom";
-import { Menu, Button, Icon, Grid, Header } from "semantic-ui-react";
-import { currentViewMonthVar } from "../cache";
-import { ALL_ENTRIES } from "../queries";
-import { Entry } from "../types";
-import { GetCurrentViewMonth, IsLoggedIn } from "../utils";
+import { Menu, Button, Icon, Grid } from "semantic-ui-react";
+import { IsLoggedIn } from "../utils";
 import CustomMenuItemWithLink from "./CustomMenuItemWithLink";
+import DateFilter from "./DateFilter";
 
 interface NavigationProps {
   openLoginModal: () => void;
@@ -24,75 +20,6 @@ const BottomNavigation = ({
   openLoginModal,
 }: NavigationProps) => {
   const location = useLocation();
-
-  const currentViewMonth = GetCurrentViewMonth();
-  const today = new Date();
-  const initMonth = new Date(today.getFullYear(), today.getMonth());
-  const [dateFilter, setDateFilter] = useState<Date>(initMonth);
-
-  const entries = useQuery(ALL_ENTRIES);
-  const [oldestDate, setOldestDate] = useState<Date>(initMonth);
-  const [newestDate, setNewestDate] = useState<Date>(initMonth);
-  const [prevButtonDisabled, setPrevButtonDisabled] = useState<boolean>(true);
-  const [nextButtonDisabled, setNextButtonDisabled] = useState<boolean>(true);
-
-  useEffect(() => {
-    setDateFilter(currentViewMonth);
-  }, [currentViewMonth]);
-
-  useEffect(() => {
-    if (entries.data) {
-      const sortedEntries = [...entries.data.returnAllEntries].sort(
-        (a: Entry, b: Entry) => {
-          const aDate = new Date(a.date);
-          const bDate = new Date(b.date);
-          return aDate.valueOf() - bDate.valueOf();
-        }
-      );
-      const oldestEntryDate = new Date(
-        sortedEntries.length > 0 ? sortedEntries[0].date : new Date()
-      );
-      const newestEntryDate = new Date(
-        sortedEntries.length > 0
-          ? sortedEntries[sortedEntries.length - 1].date
-          : new Date()
-      );
-      setOldestDate(oldestEntryDate);
-      setNewestDate(
-        new Date(newestEntryDate.getFullYear(), newestEntryDate.getMonth())
-      );
-    }
-  }, [entries.data]);
-
-  useEffect(() => {
-    if (dateFilter <= oldestDate) setPrevButtonDisabled(true);
-    if (dateFilter > oldestDate) setPrevButtonDisabled(false);
-    if (dateFilter >= newestDate) setNextButtonDisabled(true);
-    if (dateFilter < newestDate) setNextButtonDisabled(false);
-  }, [dateFilter, newestDate, oldestDate]);
-
-  const prevMonth = () => {
-    const newMonth = new Date(
-      dateFilter.getFullYear(),
-      dateFilter.getMonth() - 1
-    );
-    currentViewMonthVar(newMonth);
-    setDateFilter(newMonth);
-  };
-
-  const nextMonth = () => {
-    const newMonth = new Date(
-      dateFilter.getFullYear(),
-      dateFilter.getMonth() + 1
-    );
-    currentViewMonthVar(newMonth);
-    setDateFilter(newMonth);
-  };
-
-  const resetMonth = () => {
-    currentViewMonthVar(initMonth);
-    setDateFilter(initMonth);
-  };
 
   return (
     <div
@@ -132,41 +59,7 @@ const BottomNavigation = ({
             (location.pathname === `/${entriesPath}` ||
               location.pathname === "/") ? (
               <Grid.Column floated="left">
-                <Menu size="mini" borderless compact>
-                  <Menu.Item fitted>
-                    <Button
-                      attached="left"
-                      size="mini"
-                      disabled={prevButtonDisabled}
-                      onClick={() => prevMonth()}
-                    >
-                      <Icon name="caret left" inverted color="black" />
-                    </Button>
-                  </Menu.Item>
-                  <Button
-                    as={Menu.Item}
-                    size="mini"
-                    onClick={() => resetMonth()}
-                    fitted
-                  >
-                    <Header as="h4" style={{ padding: "0 1em" }}>
-                      {dateFilter.toLocaleString("default", {
-                        month: "short",
-                        year: "2-digit",
-                      })}
-                    </Header>
-                  </Button>
-                  <Menu.Item fitted>
-                    <Button
-                      attached="right"
-                      size="mini"
-                      disabled={nextButtonDisabled}
-                      onClick={() => nextMonth()}
-                    >
-                      <Icon name="caret right" />
-                    </Button>
-                  </Menu.Item>
-                </Menu>
+                <DateFilter />
               </Grid.Column>
             ) : null}
             <Grid.Column>

--- a/client/src/components/DateFilter.tsx
+++ b/client/src/components/DateFilter.tsx
@@ -1,5 +1,13 @@
-import { useState } from "react";
-import { Menu, Button, Icon, Header, Popup, Form } from "semantic-ui-react";
+import { ChangeEvent, useState } from "react";
+import {
+  Menu,
+  Button,
+  Icon,
+  Header,
+  Popup,
+  Form,
+  Divider,
+} from "semantic-ui-react";
 import { currentViewDateRangeVar } from "../cache";
 import { ViewDateRange } from "../types";
 
@@ -38,6 +46,25 @@ const DateFilter = () => {
     setDateFilter(newDate);
   };
 
+  const handleDateFilterChange = (
+    event: ChangeEvent<HTMLInputElement>,
+    isStart: boolean
+  ) => {
+    console.log(event.target.value);
+    if (isStart) {
+      const newStart = new Date(event.target.value);
+      const newDate = { start: newStart, end: dateFilter.end };
+      currentViewDateRangeVar(newDate);
+      setDateFilter(newDate);
+    } else {
+      const newEnd = new Date(event.target.value);
+      const newDate = { start: dateFilter.start, end: newEnd };
+      currentViewDateRangeVar(newDate);
+      setDateFilter(newDate);
+    }
+    console.log(dateFilter);
+  };
+
   const resetMonth = () => {
     currentViewDateRangeVar(initDate);
     setDateFilter(initDate);
@@ -62,16 +89,24 @@ const DateFilter = () => {
               </Header>
             </Button>
           }
+          position="top center"
         >
           <Form>
             <Form.Input
               label="Start"
               type="date"
-              value={dateFilter.start.toString()}
+              onChange={(event) => handleDateFilterChange(event, true)}
+              //value={getYearMonthDay(dateFilter.start)}
             />
-            <Form.Input label="End" type="date" value={dateFilter.end} />
+            <Form.Input
+              label="End"
+              type="date"
+              onChange={(event) => handleDateFilterChange(event, false)}
+              //value={getYearMonthDay(dateFilter.end)}
+            />
           </Form>
-          <Button onClick={() => resetMonth()}>View ongoing</Button>
+          <Divider />
+          <Button onClick={() => resetMonth()}>Reset</Button>
         </Popup>
         <Menu.Item fitted>
           <Button attached="right" size="mini" onClick={() => nextMonth()}>

--- a/client/src/components/DateFilter.tsx
+++ b/client/src/components/DateFilter.tsx
@@ -46,7 +46,7 @@ const DateFilter = () => {
   const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
   const initDate = { start: startInit, end: endInit };
   const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
-  const [popupIsOpen, setPopupIsOpen] = useState<boolean>(true);
+  const [popupIsOpen, setPopupIsOpen] = useState<boolean>(false);
 
   const prevMonth = () => {
     const newStart = new Date(

--- a/client/src/components/DateFilter.tsx
+++ b/client/src/components/DateFilter.tsx
@@ -1,0 +1,86 @@
+import { useState } from "react";
+import { Menu, Button, Icon, Header, Popup, Form } from "semantic-ui-react";
+import { currentViewDateRangeVar } from "../cache";
+import { ViewDateRange } from "../types";
+
+const DateFilter = () => {
+  const today = new Date();
+  const startInit = new Date(today.getFullYear(), today.getMonth());
+  const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
+  const initDate = { start: startInit, end: endInit };
+  const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
+
+  const prevMonth = () => {
+    const newStart = new Date(
+      dateFilter.start.getFullYear(),
+      dateFilter.start.getMonth() - 1
+    );
+    const newEnd = new Date(
+      dateFilter.end.getFullYear(),
+      dateFilter.end.getMonth() - 1
+    );
+    const newDate = { start: newStart, end: newEnd };
+    currentViewDateRangeVar(newDate);
+    setDateFilter(newDate);
+  };
+
+  const nextMonth = () => {
+    const newStart = new Date(
+      dateFilter.start.getFullYear(),
+      dateFilter.start.getMonth() + 1
+    );
+    const newEnd = new Date(
+      dateFilter.end.getFullYear(),
+      dateFilter.end.getMonth() + 1
+    );
+    const newDate = { start: newStart, end: newEnd };
+    currentViewDateRangeVar(newDate);
+    setDateFilter(newDate);
+  };
+
+  const resetMonth = () => {
+    currentViewDateRangeVar(initDate);
+    setDateFilter(initDate);
+  };
+
+  return (
+    <>
+      <Menu size="mini" borderless compact>
+        <Menu.Item fitted>
+          <Button attached="left" size="mini" onClick={() => prevMonth()}>
+            <Icon name="caret left" inverted color="black" />
+          </Button>
+        </Menu.Item>
+        <Popup
+          trigger={
+            <Button as={Menu.Item} size="mini" fitted>
+              <Header as="h4" style={{ padding: "0 1em" }}>
+                {dateFilter.start.toLocaleString("default", {
+                  month: "short",
+                  year: "2-digit",
+                })}
+              </Header>
+            </Button>
+          }
+        >
+          <Form>
+            <Form.Input
+              label="Start"
+              type="date"
+              value={dateFilter.start.toString()}
+            />
+            <Form.Input label="End" type="date" value={dateFilter.end} />
+          </Form>
+          <Button onClick={() => resetMonth()}>View ongoing</Button>
+        </Popup>
+        <Menu.Item fitted>
+          <Button attached="right" size="mini" onClick={() => nextMonth()}>
+            <Icon name="caret right" />
+          </Button>
+        </Menu.Item>
+      </Menu>
+    </>
+  );
+};
+
+export default DateFilter;

--- a/client/src/components/Entry.tsx
+++ b/client/src/components/Entry.tsx
@@ -1,6 +1,6 @@
 import { Button, Card, Feed, Header, Icon } from "semantic-ui-react";
 import { Entry as EntryType } from "../types";
-import { getYearMonthDay } from "../utils";
+import { getYearMonthDay } from "../utils/dates";
 
 interface SingleEntryProps {
   entry: EntryType;

--- a/client/src/components/EntryForm.tsx
+++ b/client/src/components/EntryForm.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import * as Yup from "yup";
 import { FormikProps, Field } from "formik";
 import { useState, useEffect } from "react";

--- a/client/src/components/EntryModal.tsx
+++ b/client/src/components/EntryModal.tsx
@@ -8,7 +8,8 @@ import {
   UPDATE_ENTRY,
   DELETE_ENTRY,
 } from "../queries";
-import { getYearMonthDay, toNewEntry } from "../utils";
+import { toNewEntry } from "../utils";
+import { getYearMonthDay } from "../utils/dates";
 import NewEntryForm from "./NewEntryForm";
 import UpdateEntryForm from "./UpdateEntryForm";
 

--- a/client/src/components/NewEntryForm.tsx
+++ b/client/src/components/NewEntryForm.tsx
@@ -1,6 +1,6 @@
 import { withFormik } from "formik";
 import { IncomeExpenseType } from "../types";
-import { getYearMonthDay } from "../utils";
+import { getYearMonthDay } from "../utils/dates";
 import EntryForm, { EntryFormValues, EntryValidationSchema } from "./EntryForm";
 
 interface NewEntryFormProps {

--- a/client/src/components/SpendByCategoryTable.tsx
+++ b/client/src/components/SpendByCategoryTable.tsx
@@ -2,7 +2,7 @@ import _ from "lodash";
 import { useEffect, useReducer } from "react";
 import { Header, Icon, Table } from "semantic-ui-react";
 import { CustomPieChartData } from "../types";
-import { getCountOfDaysInMonth } from "../utils";
+import { getCountOfDaysInMonth } from "../utils/dates";
 
 const getWeeklyBudget = (budget: number): number => {
   const today = new Date();

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -24,6 +24,7 @@ import {
   entriesToIncomeAndExpenseSumBarData,
   entriesToIncomeAndExpenseSumBarDataKeys,
 } from "../utils/data";
+import { getYearMonth } from "../utils/dates";
 import { NoEntries } from "./Entries";
 
 const Dashboard = () => {
@@ -41,9 +42,8 @@ const Dashboard = () => {
     useState<CustomPieChartData[]>();
 
   const currentViewDateRange = useQuery(GET_CURRENT_VIEW_RANGE);
-  const today = new Date();
-  const startInit = new Date(today.getFullYear(), today.getMonth());
-  const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
+  const startInit = getYearMonth({});
+  const endInit = getYearMonth({ addMonth: 1 });
   const initDate = { start: startInit, end: endInit };
   const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
 

--- a/client/src/pages/Dashboard.tsx
+++ b/client/src/pages/Dashboard.tsx
@@ -10,9 +10,14 @@ import SpendByCategoryTable from "../components/SpendByCategoryTable";
 import {
   ALL_CATEGORIES,
   ALL_ENTRIES,
-  GET_CURRENT_VIEW_MONTH,
+  GET_CURRENT_VIEW_RANGE,
 } from "../queries";
-import { CustomPieChartData, Entry, IncomeExpenseType } from "../types";
+import {
+  CustomPieChartData,
+  Entry,
+  IncomeExpenseType,
+  ViewDateRange,
+} from "../types";
 import {
   categoriesToIdAndValue,
   entriesByCategoryToIdAndValue,
@@ -35,26 +40,23 @@ const Dashboard = () => {
   const [incomesByCategory, setIncomesByCategory] =
     useState<CustomPieChartData[]>();
 
+  const currentViewDateRange = useQuery(GET_CURRENT_VIEW_RANGE);
   const today = new Date();
-  const currentViewMonth = useQuery(GET_CURRENT_VIEW_MONTH);
-  const [dateFilter, setDateFilter] = useState<Date>(
-    new Date(today.getFullYear(), today.getMonth())
-  );
+  const startInit = new Date(today.getFullYear(), today.getMonth());
+  const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
+  const initDate = { start: startInit, end: endInit };
+  const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
 
   useEffect(() => {
-    setDateFilter(currentViewMonth.data.currentViewMonth);
-  }, [currentViewMonth]);
+    setDateFilter(currentViewDateRange.data.currentViewMonth);
+  }, [currentViewDateRange]);
 
   useEffect(() => {
     if (getEntries.data) {
       const entries = getEntries.data.returnAllEntries.filter(
         (entry: Entry) => {
           const entryDate = new Date(entry.date);
-          const endOfMonth = new Date(
-            dateFilter.getFullYear(),
-            dateFilter.getMonth() + 1
-          );
-          return entryDate >= dateFilter && entryDate < endOfMonth;
+          return entryDate >= dateFilter.start && entryDate < dateFilter.end;
         }
       );
 

--- a/client/src/pages/Entries.tsx
+++ b/client/src/pages/Entries.tsx
@@ -6,6 +6,7 @@ import { Feed } from "semantic-ui-react";
 import EntryModal from "../components/EntryModal";
 import { IsLoggedIn } from "../utils";
 import Entry from "../components/Entry";
+import { getYearMonth } from "../utils/dates";
 
 export const NoEntries = () => (
   <div>No entries. Please add some using the "New entry" button below.</div>
@@ -22,9 +23,8 @@ const Entries = () => {
   >(undefined);
 
   const currentViewDateRange = useQuery(GET_CURRENT_VIEW_RANGE);
-  const today = new Date();
-  const startInit = new Date(today.getFullYear(), today.getMonth());
-  const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
+  const startInit = getYearMonth({});
+  const endInit = getYearMonth({ addMonth: 1 });
   const initDate = { start: startInit, end: endInit };
   const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
 

--- a/client/src/pages/Entries.tsx
+++ b/client/src/pages/Entries.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState } from "react";
 import { useQuery } from "@apollo/client";
-import { ALL_ENTRIES, GET_CURRENT_VIEW_MONTH } from "../queries";
-import { Entry as EntryType } from "../types";
+import { ALL_ENTRIES, GET_CURRENT_VIEW_RANGE } from "../queries";
+import { Entry as EntryType, ViewDateRange } from "../types";
 import { Feed } from "semantic-ui-react";
 import EntryModal from "../components/EntryModal";
 import { IsLoggedIn } from "../utils";
@@ -20,26 +20,24 @@ const Entries = () => {
   const [updateEntryValues, setUpdateEntryValues] = React.useState<
     EntryType | undefined
   >(undefined);
+
+  const currentViewDateRange = useQuery(GET_CURRENT_VIEW_RANGE);
   const today = new Date();
-  const currentViewMonth = useQuery(GET_CURRENT_VIEW_MONTH);
-  const [dateFilter, setDateFilter] = useState<Date>(
-    new Date(today.getFullYear(), today.getMonth())
-  );
+  const startInit = new Date(today.getFullYear(), today.getMonth());
+  const endInit = new Date(today.getFullYear(), today.getMonth() + 1);
+  const initDate = { start: startInit, end: endInit };
+  const [dateFilter, setDateFilter] = useState<ViewDateRange>(initDate);
 
   useEffect(() => {
-    setDateFilter(currentViewMonth.data.currentViewMonth);
-  }, [currentViewMonth]);
+    setDateFilter(currentViewDateRange.data.currentViewMonth);
+  }, [currentViewDateRange]);
 
   React.useEffect(() => {
     if (getEntries.data) {
       setEntries(
         getEntries.data.returnAllEntries.filter((entry: EntryType) => {
           const entryDate = new Date(entry.date);
-          const endOfMonth = new Date(
-            dateFilter.getFullYear(),
-            dateFilter.getMonth() + 1
-          );
-          return entryDate >= dateFilter && entryDate < endOfMonth;
+          return entryDate >= dateFilter.start && entryDate < dateFilter.end;
         })
       );
     }

--- a/client/src/queries.ts
+++ b/client/src/queries.ts
@@ -19,7 +19,7 @@ export const GET_ACTIVE_SPACE = gql`
   }
 `;
 
-export const GET_CURRENT_VIEW_MONTH = gql`
+export const GET_CURRENT_VIEW_RANGE = gql`
   query CurrentViewMonth {
     currentViewMonth @client
   }

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -61,6 +61,11 @@ export interface EntryInput {
 
 export type localStorageUser = Omit<User, "id" | "email"> | null;
 
+export type ViewDateRange = {
+  start: Date;
+  end: Date;
+};
+
 export interface CustomPieChartData {
   id: string;
   value: number;

--- a/client/src/utils/dates.tsx
+++ b/client/src/utils/dates.tsx
@@ -11,6 +11,6 @@ export const getYearMonthDay = (date = new Date()): string => {
 export const getCountOfDaysInMonth = (year: number, month: number): number =>
   new Date(year, month, 0).getDate();
 
-export const getYearMonth = (date: Date) => {
-  return date;
+export const getYearMonth = ({ date = new Date(), addMonth = 0 }): Date => {
+  return new Date(date.getFullYear(), date.getMonth() + addMonth);
 };

--- a/client/src/utils/dates.tsx
+++ b/client/src/utils/dates.tsx
@@ -1,0 +1,16 @@
+export const getYearMonthDay = (date = new Date()): string => {
+  if (!(date instanceof Date)) {
+    date = new Date(date);
+  }
+  const month =
+    date.getMonth() < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
+  const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
+  return `${date.getFullYear()}-${month}-${day}`;
+};
+
+export const getCountOfDaysInMonth = (year: number, month: number): number =>
+  new Date(year, month, 0).getDate();
+
+export const getYearMonth = (date: Date) => {
+  return date;
+};

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -12,7 +12,7 @@ import {
   IS_LOGGED_IN,
   GET_ME,
   GET_ACTIVE_SPACE,
-  GET_CURRENT_VIEW_MONTH,
+  GET_CURRENT_VIEW_RANGE,
 } from "../queries";
 import { isLoggedInVar, currentUserVar } from "../cache";
 
@@ -33,7 +33,7 @@ export const GetActiveSpace = (): Space => {
 };
 
 export const GetCurrentViewMonth = (): Date => {
-  const { data } = useQuery(GET_CURRENT_VIEW_MONTH);
+  const { data } = useQuery(GET_CURRENT_VIEW_RANGE);
   return data.currentViewMonth;
 };
 

--- a/client/src/utils/index.tsx
+++ b/client/src/utils/index.tsx
@@ -139,16 +139,3 @@ export const toNewCategory = (object: CategoryInput): NewCategory => {
   };
   return newCategory;
 };
-
-export const getYearMonthDay = (date = new Date()): string => {
-  if (!(date instanceof Date)) {
-    date = new Date(date);
-  }
-  const month =
-    date.getMonth() < 10 ? `0${date.getMonth() + 1}` : date.getMonth() + 1;
-  const day = date.getDate() < 10 ? `0${date.getDate()}` : date.getDate();
-  return `${date.getFullYear()}-${month}-${day}`;
-};
-
-export const getCountOfDaysInMonth = (year: number, month: number): number =>
-  new Date(year, month, 0).getDate();


### PR DESCRIPTION
Refactored
 - Month selection component into its own file `DateFiltering`.
 - State `currentViewMonthVar` to `currentViewDateRange` to enable start and end date selections (not only full months).
 - Extracted date related util functions to `utils/dates`.

New
- `DateFiltering` component with popup to select desired start and end dates.